### PR TITLE
Improved Reference Metric and SIMD

### DIFF
--- a/SIMD.py
+++ b/SIMD.py
@@ -1,26 +1,29 @@
-from sympy import Integer,Symbol,symbols,simplify,Rational,sign,Function,srepr,sin,cos,exp,log,Abs,Add,Mul,Pow,preorder_traversal,N,Float,S,var,sympify
+from sympy import (Integer, Rational, Float, Function, Symbol,
+    Add, Mul, Pow, Abs, S, N, sign, srepr, simplify, sympify, 
+    var, sin, cos, exp, log, symbols, preorder_traversal)
+from SIMDExprTree import ExprTree
 import re, sys
 
 # For debugging purposes, Part 1:
 # Basic arithmetic operations
 def ConstSIMD_check(a):
-    return Float(a,34)
+    return Float(a, 34)
 def AbsSIMD_check(a):
     return Abs(a)
 def nrpyAbsSIMD_check(a):
     return Abs(a)
-def AddSIMD_check(a,b):
-    return a+b
-def SubSIMD_check(a,b):
-    return a-b
-def MulSIMD_check(a,b):
-    return a*b
-def FusedMulAddSIMD_check(a,b,c):
+def AddSIMD_check(a, b):
+    return a + b
+def SubSIMD_check(a, b):
+    return a - b
+def MulSIMD_check(a, b):
+    return a * b
+def FusedMulAddSIMD_check(a, b, c):
     return a*b + c
-def FusedMulSubSIMD_check(a,b,c):
+def FusedMulSubSIMD_check(a, b, c):
     return a*b - c
-def DivSIMD_check(a,b):
-    return a/b
+def DivSIMD_check(a, b):
+    return a / b
 def signSIMD_check(a):
     return sign(a)
 
@@ -29,9 +32,9 @@ def signSIMD_check(a):
 def PowSIMD_check(a, b):
     return a**b
 def SqrtSIMD_check(a):
-    return a**(Rational(1,2))
+    return a**(Rational(1, 2))
 def CbrtSIMD_check(a):
-    return a**(Rational(1,3))
+    return a**(Rational(1, 3))
 def ExpSIMD_check(a):
     return exp(a)
 def LogSIMD_check(a):
@@ -47,53 +50,57 @@ def CosSIMD_check(a):
 # Resolution: This function extends lists "SIMD_const_varnms" and "SIMD_const_values",
 #             which store the name of each constant SIMD array (e.g., _Integer_1) and
 #             the value of each variable (e.g., 1.0).
-def expr_convert_to_SIMD_intrins(expr,  SIMD_const_varnms,SIMD_const_values,SIMD_const_suffix="",debug="False"):
+def expr_convert_to_SIMD_intrins(expr, SIMD_const_varnms, SIMD_const_values, SIMD_const_suffix="", debug="False"):
 
     # Declare all variables, so we can eval them in the next (AddSIMD & MulSIMD) step
     for item in preorder_traversal(expr):
-        for i in range(len(item.args)):
-            if isinstance(item.args[i],Symbol):
-                var(str(item.args[i]))
+        for arg in item.args:
+            if isinstance(arg, Symbol):
+                var(str(arg))
 
     expr_orig = expr
+    tree = ExprTree(expr)
 
-    AbsSIMD = Function("AbsSIMD")
-    AddSIMD = Function("AddSIMD")
-    SubSIMD = Function("SubSIMD")
-    MulSIMD = Function("MulSIMD")
+    AbsSIMD  = Function("AbsSIMD")
+    AddSIMD  = Function("AddSIMD")
+    SubSIMD  = Function("SubSIMD")
+    MulSIMD  = Function("MulSIMD")
     FusedMulAddSIMD = Function("FusedMulAddSIMD")
     FusedMulSubSIMD = Function("FusedMulSubSIMD")
-    DivSIMD = Function("DivSIMD")
+    DivSIMD  = Function("DivSIMD")
     SignSIMD = Function("SignSIMD")
 
-    PowSIMD = Function("PowSIMD")
+    PowSIMD  = Function("PowSIMD")
     SqrtSIMD = Function("SqrtSIMD")
     CbrtSIMD = Function("CbrtSIMD")
-    ExpSIMD = Function("ExpSIMD")
-    LogSIMD = Function("LogSIMD")
-    SinSIMD = Function("SinSIMD")
-    CosSIMD = Function("CosSIMD")
+    ExpSIMD  = Function("ExpSIMD")
+    LogSIMD  = Function("LogSIMD")
+    SinSIMD  = Function("SinSIMD")
+    CosSIMD  = Function("CosSIMD")
 
     # Step 1: Replace transcendental, power, and division functions with SIMD equivalents
     #         Note that due to how SymPy expresses rational numbers, the following does not
     #         affect fractional expressions of integers
-    for item in preorder_traversal(expr):
-        if item.func == Abs:
-            expr = expr.xreplace({item: AbsSIMD(item.args[0])})
-        elif item.func == exp:
-            expr = expr.xreplace({item: ExpSIMD(item.args[0])})
-        elif item.func == log:
-            expr = expr.xreplace({item: LogSIMD(item.args[0])})
-        elif item.func == sin:
-            expr = expr.xreplace({item: SinSIMD(item.args[0])})
-        elif item.func == cos:
-            expr = expr.xreplace({item: CosSIMD(item.args[0])})
-        elif item.func == sign:
-            expr = expr.xreplace({item: SignSIMD(item.args[0])})
+    for subtree in tree.preorder(tree.root):
+        func = subtree.expr.func
+        args = subtree.expr.args
+        if   func == Abs:
+            subtree.expr = AbsSIMD(args[0])
+        elif func == exp:
+            subtree.expr = ExpSIMD(args[0])
+        elif func == log:
+            subtree.expr = LogSIMD(args[0])
+        elif func == sin:
+            subtree.expr = SinSIMD(args[0])
+        elif func == cos:
+            subtree.expr = CosSIMD(args[0])
+        elif func == sign:
+            subtree.expr = SignSIMD(args[0])
+    expr = tree.reconstruct()
 
     # Fun little recursive function for constructing integer powers:
     def IntegerPowSIMD(a, n):
-        if n == 2:
+        if   n == 2:
             return MulSIMD(a, a)
         elif n > 2:
             return MulSIMD(IntegerPowSIMD(a, n - 1), a)
@@ -102,18 +109,25 @@ def expr_convert_to_SIMD_intrins(expr,  SIMD_const_varnms,SIMD_const_values,SIMD
         elif n == -1:
             return DivSIMD(1, a)
 
-    for item in preorder_traversal(expr):
-        if item.func == Pow:
-            if item.args[1] == 0.5:
-                expr = expr.xreplace({item: SqrtSIMD(item.args[0])})
-            elif item.args[1] == -0.5:
-                expr = expr.xreplace({item: DivSIMD(1,SqrtSIMD(item.args[0]))})
-            elif item.args[1] == Rational(1,3):
-                expr = expr.xreplace({item: CbrtSIMD(item.args[0])})
-            elif item.args[1] == int(item.args[1]):
-                expr = expr.xreplace({item: IntegerPowSIMD(item.args[0], item.args[1])})
+    for subtree in tree.preorder(tree.root):
+        func = subtree.expr.func
+        args = subtree.expr.args
+        if func == Pow:
+            if   args[1] == 0.5:
+                subtree.expr = SqrtSIMD(args[0])
+                subtree.children.pop(1) # Remove 0.5
+            elif args[1] == -0.5:
+                subtree.expr = DivSIMD(1, SqrtSIMD(args[0]))
+                tree.build(subtree, clear=True)
+            elif args[1] == Rational(1, 3):
+                subtree.expr = CbrtSIMD(args[0])
+                subtree.children.pop(1) # Remove -0.5
+            elif args[1] == int(args[1]):
+                subtree.expr = IntegerPowSIMD(*args)
+                tree.build(subtree, clear=True)
             else:
-                expr = expr.xreplace({item:        PowSIMD(item.args[0], item.args[1])})
+                subtree.expr = PowSIMD(*args)
+    expr = tree.reconstruct()
 
     # Step 2: Replace all rational numbers (expressed as Rational(a,b))
     #         and integers with the new functions RationalTMP and
@@ -121,31 +135,34 @@ def expr_convert_to_SIMD_intrins(expr,  SIMD_const_varnms,SIMD_const_values,SIMD
     #         and Integer(a) -> IntegerTMP(a)
     RationalTMP = Function("RationalTMP")
     IntegerTMP = Function("IntegerTMP")
-
-    string = str(srepr(expr))
-    string2 = re.sub(r'Integer\(([+\-0-9]+)\)',
-                     "(Function('IntegerTMP')('\\1'))", string)
-    expr = eval(string2)
-
-    string = str(srepr(expr))
-    string2 = re.sub(r'Rational\(([-0-9]+), ([0-9]+)\)',
-                     "(Function('RationalTMP')(('\\1'),('\\2')))", string)
-    expr = eval(string2)
+    
+    for subtree in tree.postorder(tree.root):
+        if isinstance(subtree.expr, Integer):
+            subtree.expr = IntegerTMP(subtree.expr)
+            tree.build(subtree, clear=True)
+        elif isinstance(subtree.expr, Rational):
+            args = subtree.expr.p, subtree.expr.q
+            subtree.expr = RationalTMP(*args)
+            tree.build(subtree, clear=True)
+    expr = tree.reconstruct(evaluate=True)
+    # We must evaluate the expression, otherwise nested multiplications
+    # will arise that conflict with the following replacements in Step 3.
 
     # Step 3: The pattern Mul(-1,Rational(a,b)) is often seen. Replace with Rational(-a,b).
-    for item in preorder_traversal(expr):
-        if item.func == Mul:
-            idx_has_Negative1 = -10
-            for i in range(len(item.args)):
-                if item.args[i].func == IntegerTMP and item.args[i].args[0] == -1:
-                    idx_has_Negative1 = i
-            if idx_has_Negative1 >= 0:
-                for i in range(len(item.args)):
-                    if item.args[i].func==RationalTMP:
-                        tempitem_orig = Mul(IntegerTMP(-1),RationalTMP(item.args[i].args[0], item.args[i].args[1]))
-                        tempitem_new  = RationalTMP(-item.args[i].args[0], item.args[i].args[1])
-                        expr = expr.subs(tempitem_orig, tempitem_new )
+    for subtree in tree.preorder(tree.root):
+        func = subtree.expr.func
+        args = subtree.children
+        if func == Mul:
+            index = -1 # Index of -1
+            for i, arg in enumerate(args):
+                if arg.expr == IntegerTMP(-1): index = i
+            if index != -1:
+                for arg in args:
+                    if arg.expr.func == RationalTMP:
+                        subtree.children.pop(index) # Remove -1
+                        arg.children[0].expr *= -1
                         break
+    expr = tree.reconstruct()
 
     # Step 4: SIMD multiplication and addition compiler intrinsics read in
     #         only two arguments at once, where SymPy's Mul() and Add()
@@ -162,31 +179,30 @@ def expr_convert_to_SIMD_intrins(expr,  SIMD_const_varnms,SIMD_const_values,SIMD
     #         This is undesirable, so we instead define new, temporary
     #         functions IntegerTMP and RationalTMP that are undisturbed by
     #         the eval()
-    for item in preorder_traversal(expr):
-        if item.func == Mul:
-            blahtmp = symbols('blahtmp')
-            tempitem = blahtmp
-            for i in range(len(item.args)-1):
-                tempitem = MulSIMD(item.args[i],tempitem)
-            tempitem = tempitem.xreplace({blahtmp: item.args[len(item.args)-1]})
-            expr = expr.xreplace({item: tempitem})
-    for item in preorder_traversal(expr):
-        if item.func == Add:
-            blahtmp = symbols('blahtmp')
-            tempitem = blahtmp
-            for i in range(len(item.args)-1):
-                tempitem = AddSIMD(item.args[i],tempitem)
-            tempitem = tempitem.xreplace({blahtmp: item.args[len(item.args)-1]})
-            expr = expr.xreplace({item: tempitem})
+    for subtree in tree.preorder(tree.root):
+        func = subtree.expr.func
+        args = subtree.expr.args
+        if (func == Mul or func == Add):
+            func = MulSIMD if func == Mul else AddSIMD
+            subexpr = func(*args[-2:])
+            for arg in args[:-2]:
+                subexpr = func(arg, subexpr, evaluate=False)
+            subtree.expr = subexpr
+            tree.build(subtree, clear=True)
+    expr = tree.reconstruct()
 
     # Step 5: Simplification patterns:
     # Step 5a: Replace the pattern Mul(Div(1,b),a) or Mul(a,Div(1,b)) with Div(a,b):
-    for item in preorder_traversal(expr):
-        if item.func == MulSIMD:
-            if item.func == MulSIMD and (item.args[0].func == DivSIMD and item.args[0].args[0].func == IntegerTMP and item.args[0].args[0].args[0] == 1):
-                expr = expr.xreplace({item: DivSIMD(item.args[1],item.args[0].args[1])})
-            if item.func == MulSIMD and (item.args[1].func == DivSIMD and item.args[1].args[0].func == IntegerTMP and item.args[1].args[0].args[0] == 1):
-                expr = expr.xreplace({item: DivSIMD(item.args[0],item.args[1].args[1])})
+    for subtree in tree.preorder(tree.root):
+        func = subtree.expr.func
+        args = subtree.expr.args
+        if   func == MulSIMD and args[0].func == DivSIMD and args[1].func == IntegerTMP:
+            subtree.expr = DivSIMD(args[1], args[0].args[1])
+            tree.build(subtree, clear=True)
+        elif func == MulSIMD and args[1].func == DivSIMD and args[0].func == IntegerTMP:
+            subtree.expr = DivSIMD(args[0], args[1].args[1])
+            tree.build(subtree, clear=True)
+    expr = tree.reconstruct()
 
     # Step 5: Subtraction intrinsics. SymPy replaces all a-b with a + (-b) = Add(a,Mul(-1,b))
     #         Here, we replace
@@ -195,25 +211,26 @@ def expr_convert_to_SIMD_intrins(expr,  SIMD_const_varnms,SIMD_const_values,SIMD
     #         c) AddSIMD(MulSIMD(-1,b),a), and
     #         d) AddSIMD(MulSIMD(b,-1),a)
     #         with SubSIMD(a,b)
-    for item in preorder_traversal(expr):
-        tempitem = item
-        # First match patterns a) and b): AddSIMD(a,MULSIMD(.,.)):
-        if item.func == AddSIMD and item.args[1].func == MulSIMD:
-            # Pattern a) AddSIMD(a,MulSIMD(-1,b)) --> SubSIMD(a,b):
-            if item.args[1].args[0].func == IntegerTMP and item.args[1].args[0].args[0] == -1:
-                tempitem = SubSIMD(item.args[0],item.args[1].args[1])
-            # Pattern b) AddSIMD(a,MulSIMD(b,-1)) --> SubSIMD(a,b):
-            elif item.args[1].args[1].func == IntegerTMP and item.args[1].args[1].args[0] == -1:
-                tempitem = SubSIMD(item.args[0],item.args[1].args[0])
-        # Next match patterns c) and d): AddSIMD(MulSIMD(.,.),a):
-        elif item.func == AddSIMD and item.args[0].func == MulSIMD:
-            # Pattern c) AddSIMD(MulSIMD(-1,b),a) --> SubSIMD(a,b):
-            if item.args[0].args[0].func == IntegerTMP and item.args[0].args[0].args[0] == -1:
-                tempitem = SubSIMD(item.args[1],item.args[0].args[1])
-            # Pattern d) AddSIMD(MulSIMD(b,-1,a)) --> SubSIMD(a,b):
-            elif item.args[0].args[1].func == IntegerTMP and item.args[0].args[1].args[0] == -1:
-                tempitem = SubSIMD(item.args[1],item.args[0].args[0])
-        expr = expr.subs(item,tempitem)
+    for subtree in tree.preorder(tree.root):
+        func = subtree.expr.func
+        args = subtree.expr.args
+        if   func == AddSIMD and args[0].func == MulSIMD and \
+                args[0].args[0] == IntegerTMP(-1):
+            subtree.expr = SubSIMD(args[1], args[0].args[1])
+            tree.build(subtree, clear=True)
+        elif func == AddSIMD and args[0].func == MulSIMD and \
+                args[0].args[1] == IntegerTMP(-1):
+            subtree.expr = SubSIMD(args[1], args[0].args[0])
+            tree.build(subtree, clear=True)
+        elif func == AddSIMD and args[1].func == MulSIMD and \
+                args[1].args[0] == IntegerTMP(-1):
+            subtree.expr = SubSIMD(args[0], args[1].args[1])
+            tree.build(subtree, clear=True)
+        elif func == AddSIMD and args[1].func == MulSIMD and \
+                args[1].args[1] == IntegerTMP(-1):
+            subtree.expr = SubSIMD(args[0], args[1].args[0])
+            tree.build(subtree, clear=True)
+    expr = tree.reconstruct()
 
     # Step 6: Now that all multiplication and addition functions only take two
     #         arguments, we can now easily define fused-multiply-add functions,
@@ -222,89 +239,80 @@ def expr_convert_to_SIMD_intrins(expr,  SIMD_const_varnms,SIMD_const_values,SIMD
     # Fused multiply add (FMA3) is standard on Intel CPUs with the AVX2
     #         instruction set, starting with Haswell processors in 2013:
     #         https://en.wikipedia.org/wiki/Haswell_(microarchitecture)
-    for item in preorder_traversal(expr):
-        tempitem = item
-        # If the pattern is a*b + c, replace with FMA(a,b,c)
-        if item.func == AddSIMD and item.args[0].func == MulSIMD:
-            tempitem = FusedMulAddSIMD(item.args[0].args[0],item.args[0].args[1],item.args[1])
-        # If the pattern is c + a*b, replace with FMA(a,b,c)
-        if item.func == AddSIMD and item.args[1].func == MulSIMD:
-            tempitem = FusedMulAddSIMD(item.args[1].args[0],item.args[1].args[1],item.args[0])
-
-        # If the pattern is a*b - c, replace with FMS(a,b,c)
-        if item.func == SubSIMD and item.args[0].func == MulSIMD:
-            tempitem = FusedMulSubSIMD(item.args[0].args[0],item.args[0].args[1],item.args[1])
-
-        if item != tempitem: expr = expr.subs(item, tempitem)
-
-    # Step 7: SIMD intrinsics cannot take integers or rational numbers as arguments.
-    #         Therefore we must declare all integers & rational numbers as
-    #         const vector doubles (e.g., const _m256d ...). To make the code
-    #         more human readable, we adopt the convention
-    #         RationalTMP(1,3) = 1/3 = "Rational_1_3
-    #         RationalTMP(-1,3) = -1/3 = "Rational_m1_3
-    # TODO: Keep track of all integers and rationals, so repeats are not computed?
+    for subtree in tree.preorder(tree.root):
+        func = subtree.expr.func
+        args = subtree.expr.args
+        if   func == AddSIMD and args[0].func == MulSIMD:
+            subtree.expr = FusedMulAddSIMD(*args[0].args, args[1])
+            tree.build(subtree, clear=True)
+        elif func == AddSIMD and args[1].func == MulSIMD:
+            subtree.expr = FusedMulAddSIMD(*args[1].args, args[0])
+            tree.build(subtree, clear=True)
+        elif func == SubSIMD and args[0].func == MulSIMD:
+            subtree.expr = FusedMulSubSIMD(*args[0].args, args[1])
+            tree.build(subtree, clear=True)
+    expr = tree.reconstruct()
 
     # Step 7a: Set all variable names and corresponding values.
     for item in preorder_traversal(expr):
         if item.func == RationalTMP:
             # Set variable name
-            if item.args[0]*item.args[1] < 0:
-                SIMD_const_varnms.extend(["_Rational_m"+str(abs(item.args[0]))+"_"+str(abs(item.args[1]))+SIMD_const_suffix])
+            if item.args[0] * item.args[1] < 0:
+                SIMD_const_varnms.extend(["_Rational_m" + str(abs(item.args[0])) + "_" + str(abs(item.args[1])) + SIMD_const_suffix])
             elif item.args[0] > 0 and item.args[1] > 0:
-                SIMD_const_varnms.extend(["_Rational_"+str(item.args[0])+"_"+str(item.args[1])+SIMD_const_suffix])
+                SIMD_const_varnms.extend(["_Rational_" + str(item.args[0]) + "_" + str(item.args[1]) + SIMD_const_suffix])
             else:
                 # E.g., doesn't make sense to have -1/-3. SymPy should have simplified this.
-                print("Found a weird Rational(a,b) expression, where a<0 and b<0. Report to SymPy devels")
-                print("Specifically, found that a="+str(item.args[0])+" and b="+str(item.args[1]))
+                print("Found a weird Rational(a, b) expression, where a < 0 and b < 0. Report to SymPy devels.")
+                print("Specifically, found that a = " + str(item.args[0]) + " and b = " + str(item.args[1]))
                 sys.exit(1)
             # Set variable value, to 34 digits of precision
-            SIMD_const_values.extend([str(N(Float(item.args[0],34)/Float(item.args[1],34),34))])
+            SIMD_const_values.extend([str(N(Float(item.args[0], 34)/Float(item.args[1], 34), 34))])
         elif item.func == IntegerTMP:
             # Set variable name
             if item.args[0] < 0:
-                SIMD_const_varnms.extend(["_Integer_m"+str(-item.args[0])+SIMD_const_suffix])
+                SIMD_const_varnms.extend(["_Integer_m" + str(-item.args[0]) + SIMD_const_suffix])
             else:
-                SIMD_const_varnms.extend(["_Integer_" + str(item.args[0])+SIMD_const_suffix])
+                SIMD_const_varnms.extend(["_Integer_" + str(item.args[0]) + SIMD_const_suffix])
             # Set variable value, to 34 digits of precision
-            SIMD_const_values.extend([str((Float(item.args[0],34)))])
+            SIMD_const_values.extend([str((Float(item.args[0], 34)))])
 
     # Step 7b: Replace all integers and rationals with the appropriate variable names:
     for item in preorder_traversal(expr):
         tempitem = item
         if item.func == RationalTMP:
-            if item.args[0]*item.args[1] < 0:
-                tempitem = var("_Rational_m" + str(abs(item.args[0])) + "_" + str(abs(item.args[1]))+SIMD_const_suffix)
+            if item.args[0] * item.args[1] < 0:
+                tempitem = var("_Rational_m" + str(abs(item.args[0])) + "_" + str(abs(item.args[1])) + SIMD_const_suffix)
             elif item.args[0] > 0 and item.args[1] > 0:
-                tempitem = var("_Rational_" + str(item.args[0]) + "_" + str(item.args[1])+SIMD_const_suffix)
+                tempitem = var("_Rational_" + str(item.args[0]) + "_" + str(item.args[1]) + SIMD_const_suffix)
             else:
                 # E.g., doesn't make sense to have -1/-3. SymPy should have simplified this.
-                print("Found a weird Rational(a,b) expression, where a<0 and b<0. Report to SymPy devels")
-                print("Specifically, found that a=" + str(item.args[0]) + " and b=" + str(item.args[1]))
+                print("Found a weird Rational(a, b) expression, where a < 0 and b < 0. Report to SymPy devels.")
+                print("Specifically, found that a = " + str(item.args[0]) + " and b = " + str(item.args[1]))
                 sys.exit(1)
         elif item.func == IntegerTMP:
             if item.args[0] < 0:
-                tempitem = var("_Integer_m" + str(-item.args[0])+SIMD_const_suffix)
+                tempitem = var("_Integer_m" + str(-item.args[0]) + SIMD_const_suffix)
             else:
-                tempitem = var("_Integer_" + str(item.args[0])+SIMD_const_suffix)
+                tempitem = var("_Integer_" + str(item.args[0]) + SIMD_const_suffix)
         if item != tempitem: expr = expr.subs(item, tempitem)
 
     def lookup_name_output_idx(name, list_of_names):
         for i in range(len(list_of_names)):
             if list_of_names[i] == name:
                 return i
-        print("I SHOULDN'T BE HERE!",name,list_of_names)
+        print("I SHOULDN'T BE HERE!", name, list_of_names)
         sys.exit(1)
 
-    if debug=="True":
+    if debug == "True":
         expr_check = expr
         if "SIMD" in str(expr):
-            expr_check = eval(str(expr).replace("SIMD","SIMD_check"))
+            expr_check = eval(str(expr).replace("SIMD", "SIMD_check"))
 
         for item in preorder_traversal(expr_check):
             tempitem = item
-            if item.is_Symbol and str(item)[0]=="_":
-                if str(item)[:9]=="_Integer_" or str(item)[:10]=="_Rational_":
+            if item.is_Symbol and str(item)[0] == "_":
+                if str(item)[:9] == "_Integer_" or str(item)[:10] == "_Rational_":
                     tempitem = SIMD_const_values[lookup_name_output_idx(str(item), SIMD_const_varnms)]
             if item != tempitem: expr_check = expr_check.subs(item, tempitem)
 
@@ -320,5 +328,5 @@ def expr_convert_to_SIMD_intrins(expr,  SIMD_const_varnms,SIMD_const_values,SIMD
         if expr_diff != 0:
             simp_expr_diff = simplify(expr_diff)
             if simp_expr_diff != 0:
-                print("Warning: found possible diff",(simp_expr_diff))
+                print("Warning: found possible diff", (simp_expr_diff))
     return(expr)

--- a/SIMD.py
+++ b/SIMD.py
@@ -262,6 +262,12 @@ def expr_convert_to_SIMD_intrins(expr, SIMD_const_varnms, SIMD_const_values, SIM
             tree.build(subtree, clear=True)
     expr = tree.reconstruct()
 
+    # Step 7: SIMD intrinsics cannot take integers or rational numbers as arguments.
+    #         Therefore we must declare all integers & rational numbers as
+    #         const vector doubles (e.g., const _m256d ...). To make the code
+    #         more human readable, we adopt the convention
+    #         RationalTMP(1, 3)  = 1/3  = "Rational_1_3
+    #         RationalTMP(-1, 3) = -1/3 = "Rational_m1_3
     # Step 7a: Set all variable names and corresponding values.
     for item in preorder_traversal(expr):
         if item.func == RationalTMP:

--- a/SIMDExprTree.py
+++ b/SIMDExprTree.py
@@ -155,7 +155,7 @@ class ExprTree:
         return str([node.expr for node in self.preorder(self.root)])
 
     def __str__(self):
-        return f'ExprTree({self.root.expr})'
+        return 'ExprTree(%s)' % str(self.root.expr)
 
 if __name__ == "__main__":
     import doctest

--- a/SIMDExprTree.py
+++ b/SIMDExprTree.py
@@ -1,0 +1,134 @@
+__author__ = 'Ken Sible'
+
+class ExprTree:
+    """ SymPy Expression Tree (Nodal Structure) 
+    
+        >>> tree = ExprTree(cos(a + b)**2)
+        >>> print(tree)
+        ExprTree(cos(a + b)**2)
+        >>> repr(tree) # Preorder (Default)
+        [cos(a + b)**2, cos(a + b), a + b, a, b, 2]
+        >>> tree.replace({a + b: x})
+        cos(x)**2
+        >>> [str(subtree.expr.func).split('.')[-1][:-2] \
+                 for subtree in tree.preorder()]
+        ['Pow', 'cos', 'Symbol', 'Integer']
+    """
+
+    def __init__(self, expr):
+        self.root = self.Node(expr)
+        self.build(self.root)
+    
+    def build(self, node, clear=False):
+        """ Build expression (sub)tree.
+
+            :arg:   root node of (sub)tree
+            :arg:   clear children (default: False)
+
+            >>> root = tree.Node(cos(a + b)**2)
+            >>> tree.build(root)
+            >>> repr(tree)
+            [cos(a + b)**2, cos(a + b), a + b, a, b, 2]
+            >>> tree.root.expr = sin(ab)**2
+            >>> tree.build(root, clear=True)
+            >>> repr(tree)
+            [sin(ab)**2, sin(ab), ab, a, b, 2]
+        """
+        if clear: node.children.clear()
+        for arg in node.expr.args:
+            subtree = self.Node(arg)
+            node.append(subtree)
+            self.build(subtree)
+
+    def preorder(self, node=None):
+        """ Generate iterator for preorder traversal.
+
+            :arg:    root node of (sub)tree
+            :return: iterator
+
+            >>> tree = ExprTree(cos(ab)**2)
+            >>> for i, subtree in enumerate(tree.preorder()):
+                    if subtree.expr.func == Mul:
+                        print((i, subtree.expr))
+            (2, ab)
+        """
+        if node == None:
+            node = self.root
+        yield node
+        for child in node.children:
+            for subtree in self.preorder(child):
+                yield subtree
+    
+    def postorder(self, node=None):
+        """ Generate iterator for postorder traversal.
+
+            :arg:    root node of (sub)tree
+            :return: iterator
+
+            >>> tree = ExprTree(cos(ab)**2)
+            >>> for i, subtree in enumerate(tree.postorder()):
+                    if subtree.expr.func == Mul:
+                        print((i, subtree.expr))
+            (2, ab)
+        """
+        if node == None:
+            node = self.root
+        for child in node.children:
+            for subtree in self.postorder(child):
+                yield subtree
+        yield node
+    
+    def replace(self, rule):
+        """
+        Replace subexpression(s) from dictionary mapping.
+
+        :arg:    replacement dictionary {original: substitution}
+        :return: root expression
+
+        >>> tree = ExprTree(cos(a + b)**2)
+        >>> tree.replace({a + b: x})
+        cos(x)**2
+        >>> tree = ExprTree(a*b + c)
+        >>> tree.replace({a*b: x, c: y})
+        x + y
+        """
+        from sympy.parsing.sympy_parser import parse_expr
+        for expr in rule:
+            self.root.expr = parse_expr(str(self.root.expr).\
+                replace(str(expr), str(rule[expr])))
+        self.build(self.root, clear=True)
+        return self.root.expr
+    
+    def reconstruct(self, evaluate=True):
+        """
+        Reconstruct root expression from expression tree.
+
+        :arg:    evaluate root expression
+        :return: root expression
+
+        >>> tree = ExprTree(cos(a + b)**2)
+        >>> tree.root.children[0] = sin(ab)
+        >>> tree.reconstruct()
+        >>> print(tree)
+        ExprTree(sin(a + b)**2)
+        """
+        for subtree in self.postorder(self.root):
+            if subtree.children:
+                expr_list = [node.expr for node in subtree.children]
+                subtree.expr = subtree.expr.func(\
+                    *expr_list, evaluate=evaluate)
+        return self.root.expr
+
+    class Node:
+        def __init__(self, expr):
+            self.expr = expr
+            self.children = []
+
+        def append(self, node):
+            self.children.append(node)
+    
+    def __repr__(self):
+        return str([node.expr for node in self.preorder(self.root)])
+
+    def __str__(self):
+        return f'ExprTree({self.root.expr})'

--- a/reference_metric.py
+++ b/reference_metric.py
@@ -626,38 +626,23 @@ def ref_metric__hatted_quantities(SymPySimplifyExpressions=True):
         #         we will now replace SymPy functions with simple variables using rigid NRPy+ syntax,
         #         and store these variables to globals defined above.
         def make_replacements(expr):
-            sympy_version = sp.__version__.replace("rc", "...").replace("b",
-                                                                        "...")  # Ignore the rc's and b's for release candidates & betas.
+            sympy_version = sp.__version__.replace("rc","...").replace("b","...")
             sympy_major_version = int(sympy_version.split(".")[0])
             sympy_minor_version = int(sympy_version.split(".")[1])
-            if sympy_major_version < 1 or (sympy_major_version >= 1 and sympy_minor_version < 2):
-                print("Detected SymPy version " + sympy_version)
-                print("Sorry, reference metric precomputation unsupported in SymPy < 1.2!")
-                sys.exit(1)
+            outdated_version = sympy_major_version < 1 or (sympy_major_version >= 1 and sympy_minor_version < 2)
+            # The derivative representation changed with SymPy 1.2, forcing version-dependent behavior.
 
             rule = {}
             for item in sp.preorder_traversal(expr):
                 if item.func == sp.Derivative:
                     strfunc = str(item.args[0]).split('_funcform(', 1)[0]
-                    deriv_wrt, deriv_order = item.args[1][0], item.args[1][1]
-                    if deriv_wrt == xx[0]:
-                        deriv_wrt = '0'
-                    elif deriv_wrt == xx[1]:
-                        deriv_wrt = '1'
-                    elif deriv_wrt == xx[2]:
-                        deriv_wrt = '2'
-                    elif deriv_wrt == xx[3]:
-                        deriv_wrt = '3'
-                    # deriv_op = ''.join(['__D'] + \
-                    #     ['D' for i in range(deriv_order - 1)] + \
-                    #     [deriv_wrt for i in range(deriv_order)])
-                    deriv_op = "__D"
-                    for i in range(deriv_order - 1):
-                        deriv_op += "D"
-                    deriv_op += deriv_wrt
-                    for i in range(deriv_order - 1):
-                        deriv_op += deriv_wrt
-                    rule[item] = sp.sympify(strfunc + deriv_op)
+                    if outdated_version:
+                        var, order = str(item.args[1])[2:], len(item.args) - 1
+                    else:
+                        var, order = str(item.args[1][0])[2:], item.args[1][1]
+                    oper = '__D' + 'D'*(order - 1) + var*order
+                    rule[item] = sp.sympify(strfunc + oper)
+            expr = expr.xreplace(rule); rule = {}
 
             for item in sp.preorder_traversal(expr):
                 if "_funcform" in str(item.func):


### PR DESCRIPTION
I simplified the algorithm for reference_metric.py and added backward-compatibility since SymPy changed the derivative representation with SymPy 1.2. I implemented an expression tree data structure (SIMDExprTree.py) for direct manipulation of the SymPy expression tree with better performance than the build-in xreplace function. I improved the performance of the SIMD algorithm (SIMD.py) for NRPy using the previously mentioned expression tree.