### PR TITLE
Fixed Issue Preventing Partial Factorization

### DIFF
--- a/cse_helpers.py
+++ b/cse_helpers.py
@@ -86,7 +86,8 @@ def cse_preprocess(expr_list, prefix='', ignore=False, factor=True, debug=False)
             expr = tree.reconstruct()
             # Perform partial factoring on the expression(s)
             for var in map_sym_to_rat:
-                expr = sp.collect(expr, var)
+                if var != sp.Symbol(prefix + '_NegativeOne_'):
+                    expr = sp.collect(expr, var)
         if debug:
             def lookup_rational(arg):
                 if arg.func == sp.Symbol:


### PR DESCRIPTION
`const REAL_SIMD_ARRAY cf_dD0 = MulSIMD(invdx0, FusedMulAddSIMD(cf_i0m2_i1_i2, tmpFDPart1__Rational_1_12, FusedMulSubSIMD(cf_i0p1_i1_i2, tmpFDPart1__Rational_2_3, FusedMulAddSIMD(cf_i0m1_i1_i2, tmpFDPart1__Rational_2_3, MulSIMD(cf_i0p2_i1_i2, tmpFDPart1__Rational_1_12)))));`

I isolated the issue (see example above) to the factoring of _NegativeOne_.

```
expr = cos(3*a - 3*b)*Rational(2, 3) - Rational(2, 3)*x - x**(-3)
expr, var_map = cse_preprocess(expr, ignore=True, factor=True)
_NegativeOne_*(_Rational_2_3*x + x**(-3)) + _Rational_2_3*cos(_Integer_3*(_NegativeOne_*b + a))

expr, var_map = cse_preprocess(expr, ignore=False, factor=True)
_NegativeOne_/x**3 + _Rational_2_3*(-x + cos(_Integer_3*(a - b)))
```

I simply ignored factoring _NegativeOne_ (see example below). I should remark that this issue cannot occur without _NegativeOne_ since any expression has at most one rational coefficient (no double factoring).

`_NegativeOne_/x**3 + _Rational_2_3*(_NegativeOne_*x + cos(_Integer_3*(_NegativeOne_*b + a)))`

`FusedMulAddSIMD(_Rational_2_3, SubSIMD(CosSIMD(MulSIMD(_Integer_3, SubSIMD(a, b))), x), DivSIMD(_NegativeOne_, MulSIMD(MulSIMD(x, x), x)))`