### PR TITLE
Fixed Post-Processing Issue with SIMD Enabled

### DIFF
--- a/finite_difference.py
+++ b/finite_difference.py
@@ -492,14 +492,14 @@ def FD_outputC(filename,sympyexpr_list, params="", upwindcontrolvec=""):
     if upwindcontrolvec != "" and len(upwind_directions) > 0:
         NRPy_FD__Number_of_Steps += 1
 
+    default_CSE_varprefix = outCparams.CSE_varprefix
     if len(read_from_memory_Ccode) > 0:
         Coutput += indent_Ccode("/* \n * NRPy+ Finite Difference Code Generation, Step "
                                 + str(NRPy_FD_StepNumber) + " of " + str(NRPy_FD__Number_of_Steps)+
                                 ": Read from main memory and compute finite difference stencils:\n */\n")
         NRPy_FD_StepNumber = NRPy_FD_StepNumber + 1
-        default_CSE_varprefix = outCparams.CSE_varprefix
         # Prefix chosen CSE variables with "FD", for the finite difference coefficients:
-        Coutput += indent_Ccode(outputC(exprs,lhsvarnames,"returnstring",params=params + ",CSE_varprefix="+default_CSE_varprefix+"FDPart1_,includebraces=False"+",CSE_preprocess=True",
+        Coutput += indent_Ccode(outputC(exprs,lhsvarnames,"returnstring",params=params + ",CSE_varprefix="+default_CSE_varprefix+"FDPart1,includebraces=False"+",CSE_preprocess=True",
                                         prestring=read_from_memory_Ccode))
 
     # Step 5b.iv: Implement control-vector upwinding algorithm.
@@ -534,7 +534,7 @@ const REAL_SIMD_ARRAY upwind_Integer_0 = ConstSIMD(tmp_upwind_Integer_0);
         # prefix up/downwinded variables with "UpwindAlgInput".
         # Here we do not wish to have this prefix.
         Coutput += indent_Ccode(outputC(upwind_expr_list,var_list,
-                                                "returnstring",params=params + ",CSE_varprefix="+default_CSE_varprefix+"FDPart2_,includebraces=False"))
+                                                "returnstring",params=params + ",CSE_varprefix="+default_CSE_varprefix+"FDPart2,includebraces=False"))
 
     # Step 5b.v: Add input RHS & LHS expressions from
     #             sympyexpr_list[]
@@ -556,7 +556,7 @@ const REAL_SIMD_ARRAY upwind_Integer_0 = ConstSIMD(tmp_upwind_Integer_0);
     if outCparams.SIMD_enable == "True":
         for i in range(len(sympyexpr_list)):
             write_to_mem_string += "WriteSIMD(&"+sympyexpr_list[i].lhs+", __RHS_exp_"+str(i)+");\n"
-    Coutput += indent_Ccode(outputC(exprs,lhsvarnames,"returnstring", params = params+",CSE_varprefix="+default_CSE_varprefix+"FDPart3_,includebraces=False,preindent=0", prestring="",poststring=write_to_mem_string))
+    Coutput += indent_Ccode(outputC(exprs,lhsvarnames,"returnstring", params = params+",CSE_varprefix="+default_CSE_varprefix+"FDPart3,includebraces=False,preindent=0", prestring="",poststring=write_to_mem_string))
     
     # Step 6: Add consistent indentation to the output end brace. 
     #         See Step 0.b for corresponding start brace.

--- a/finite_difference.py
+++ b/finite_difference.py
@@ -492,14 +492,13 @@ def FD_outputC(filename,sympyexpr_list, params="", upwindcontrolvec=""):
     if upwindcontrolvec != "" and len(upwind_directions) > 0:
         NRPy_FD__Number_of_Steps += 1
 
-    default_CSE_varprefix = outCparams.CSE_varprefix
     if len(read_from_memory_Ccode) > 0:
         Coutput += indent_Ccode("/* \n * NRPy+ Finite Difference Code Generation, Step "
                                 + str(NRPy_FD_StepNumber) + " of " + str(NRPy_FD__Number_of_Steps)+
                                 ": Read from main memory and compute finite difference stencils:\n */\n")
         NRPy_FD_StepNumber = NRPy_FD_StepNumber + 1
         # Prefix chosen CSE variables with "FD", for the finite difference coefficients:
-        Coutput += indent_Ccode(outputC(exprs,lhsvarnames,"returnstring",params=params + ",CSE_varprefix="+default_CSE_varprefix+"FDPart1,includebraces=False"+",CSE_preprocess=True",
+        Coutput += indent_Ccode(outputC(exprs,lhsvarnames,"returnstring",params=params + ",CSE_varprefix=FDPart1,includebraces=False"+",CSE_preprocess=True",
                                         prestring=read_from_memory_Ccode))
 
     # Step 5b.iv: Implement control-vector upwinding algorithm.
@@ -534,7 +533,7 @@ const REAL_SIMD_ARRAY upwind_Integer_0 = ConstSIMD(tmp_upwind_Integer_0);
         # prefix up/downwinded variables with "UpwindAlgInput".
         # Here we do not wish to have this prefix.
         Coutput += indent_Ccode(outputC(upwind_expr_list,var_list,
-                                                "returnstring",params=params + ",CSE_varprefix="+default_CSE_varprefix+"FDPart2,includebraces=False"))
+                                                "returnstring",params=params + ",CSE_varprefix=FDPart2,includebraces=False"))
 
     # Step 5b.v: Add input RHS & LHS expressions from
     #             sympyexpr_list[]
@@ -556,7 +555,7 @@ const REAL_SIMD_ARRAY upwind_Integer_0 = ConstSIMD(tmp_upwind_Integer_0);
     if outCparams.SIMD_enable == "True":
         for i in range(len(sympyexpr_list)):
             write_to_mem_string += "WriteSIMD(&"+sympyexpr_list[i].lhs+", __RHS_exp_"+str(i)+");\n"
-    Coutput += indent_Ccode(outputC(exprs,lhsvarnames,"returnstring", params = params+",CSE_varprefix="+default_CSE_varprefix+"FDPart3,includebraces=False,preindent=0", prestring="",poststring=write_to_mem_string))
+    Coutput += indent_Ccode(outputC(exprs,lhsvarnames,"returnstring", params = params+",CSE_varprefix=FDPart3,includebraces=False,preindent=0", prestring="",poststring=write_to_mem_string))
     
     # Step 6: Add consistent indentation to the output end brace. 
     #         See Step 0.b for corresponding start brace.

--- a/outputC.py
+++ b/outputC.py
@@ -102,7 +102,7 @@ def parse_outCparams_string(params):
     outCverbose = "True"
     CSE_enable = "True"
     CSE_sorting = "canonical"
-    CSE_varprefix = ""
+    CSE_varprefix = "tmp"
     CSE_preprocess = "False"
     SIMD_enable = "False"
     SIMD_find_more_FMAsFMSs = "False" # Finding too many FMAs/FMSs can degrade performance; currently tuned to optimize BSSN
@@ -287,7 +287,7 @@ def outputC(sympyexpr, output_varname_str, filename = "stdout", params = "", pre
         SIMD_const_varnms = []
         SIMD_const_values = []
         
-        varprefix = "" if outCparams.CSE_varprefix == "tmp" else outCparams.CSE_varprefix
+        varprefix = '' if outCparams.CSE_varprefix == 'tmp' else outCparams.CSE_varprefix
         if outCparams.CSE_preprocess == "True" or outCparams.SIMD_enable == "True":
             # If CSE_preprocess == True, then perform partial factorization
             # If SIMD_enable == True, then declare _NegativeOne_ in preprocessing
@@ -296,7 +296,7 @@ def outputC(sympyexpr, output_varname_str, filename = "stdout", params = "", pre
             for v in map_sym_to_rat:
                 p, q = float(map_sym_to_rat[v].p), float(map_sym_to_rat[v].q)
                 if outCparams.SIMD_enable == "False":
-                    RATIONAL_decls += outCparams.preindent + indent + "const double " + str(v) + ' = '
+                    RATIONAL_decls += outCparams.preindent + indent + 'const double ' + str(v) + ' = '
                     # Since Integer is a subclass of Rational in SymPy, we need only check whether
                     # the denominator q = 1 to determine if a rational is an integer.
                     if q != 1: RATIONAL_decls += str(p) + '/' + str(q) + ';\n'

--- a/outputC.py
+++ b/outputC.py
@@ -356,8 +356,8 @@ def outputC(sympyexpr, output_varname_str, filename = "stdout", params = "", pre
                 if outCparams.enable_TYPE == "False":
                     SIMD_RATIONAL_decls += outCparams.preindent + indent + SIMD_const_varnms[i] + " = " + SIMD_const_values[i]+";"
                 else:
-                    SIMD_RATIONAL_decls += outCparams.preindent + indent + "const double " + "_" + SIMD_const_varnms[i] + " = " + SIMD_const_values[i] + ";\n"
-                    SIMD_RATIONAL_decls += outCparams.preindent+indent+ "const REAL_SIMD_ARRAY " + SIMD_const_varnms[i] + " = ConstSIMD(" + "_" + SIMD_const_varnms[i] + ");\n"
+                    SIMD_RATIONAL_decls += outCparams.preindent + indent + "const double " + "tmp" + SIMD_const_varnms[i] + " = " + SIMD_const_values[i] + ";\n"
+                    SIMD_RATIONAL_decls += outCparams.preindent+indent+ "const REAL_SIMD_ARRAY " + SIMD_const_varnms[i] + " = ConstSIMD(" + "tmp" + SIMD_const_varnms[i] + ");\n"
                 SIMD_RATIONAL_decls += "\n"
 
     # Step 7: Construct final output string


### PR DESCRIPTION
The post-processing method should back-substitute any negative symbol, irregardless of the number of occurrences in the reduced expression (from CSE). However, this wasn't happening when SIMD was enabled.

Remark: The double underscore was removed and the naming scheme was simplified.