### PR TITLE
Interpolate vector potential to cell-corners

### DIFF
--- a/Tutorial-ETK_thorn-Interpolation_to_Arbitrary_Grids_multi_order.ipynb
+++ b/Tutorial-ETK_thorn-Interpolation_to_Arbitrary_Grids_multi_order.ipynb
@@ -541,7 +541,18 @@
     "  //    without needing a malloc().\n",
     "  char gf_name[100]; get_gf_name(*InterpCounter,gf_name);\n",
     "  char filename_basename[100];\n",
-    "  sprintf(filename_basename,\"cell_centered_points\");\n",
+    "\n",
+    "  // The following \"if\" statement is destination-code dependent.\n",
+    "  // In our case, since we are interpolating variables for harm3d,\n",
+    "  // we interpolate the vector potential to the corners of each cell.\n",
+    "  // Every other quantity is interpolated to the center of each cell.\n",
+    "  if(strncmp(gf_name,\"Unstaggered\",11) == 0){\n",
+    "      sprintf(filename_basename,\"corner_points\");\n",
+    "      }\n",
+    "  else{\n",
+    "      sprintf(filename_basename,\"cell_centered_points\");\n",
+    "      }\n",
+    "\n",
     "  int num_interp_orders,*interp_orders_list;\n",
     "  // 4-metric & 4-Christoffels only output interpolation order==4.\n",
     "  if(strncmp(gf_name,\"4-\",2) == 0) {\n",
@@ -2509,7 +2520,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.2"
+   "version": "3.6.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Modifying Tutorial-ETK_thorn-Interpolation_to_Arbitrary_Grids_multi_order.ipynb
so it interpolates the vector potential to the corners of each destination-cell.

The purpose of this modification is the proper handing off of data to harm3d,
that requires the vector potential at the corners to calculate its curl.