### PR TITLE
Allow for machines that don't set USER and don't have pwd

### DIFF
--- a/cactusthorn.py
+++ b/cactusthorn.py
@@ -17,6 +17,13 @@ from sympy.core.symbol import Symbol
 import indexedexp as ixp
 from fstr import f
 
+def get_user():
+    try:
+        import pwd
+        return pwd.getpwuid(os.getuid()).pw_name
+    except:
+        return os.environ.get("USER","jovyan")
+
 def flatten(lists):
     new_list = []
     for item in lists:
@@ -621,11 +628,9 @@ class CactusThorn:
                     if 'email' in user and self.email is None:
                         self.email = user['email']
         if self.author is None:
-            import pwd
-            self.author = pwd.getpwuid(os.getuid()).pw_name
+            self.author = get_user()
         if self.email is None:
-            import pwd
-            self.email = pwd.getpwuid(os.getuid()).pw_name
+            self.email = get_user()
 
     def get_full_name(self,gf_name):
         gfthorn = grid.find_gfmodule(gf_name,die=False)


### PR DESCRIPTION
I created a get_user() routine which will handle the exception thrown by a lack of pwd library. If it can't find that, it tries to get USER from the environment. If that also fails, it just assumes the user's name is "jovyan." This is harmless as it only affects the generation of doc files by cactusthorn.py