### PR TITLE
Fix for PointDesc::DI access

### DIFF
--- a/cactusthorn.py
+++ b/cactusthorn.py
@@ -889,7 +889,6 @@ schedule {self.thornname}_RegisterVars in MoL_Register
                             print( "  using CCTK_BOOLVEC = simdl<CCTK_REAL>;",file=fd)
                             print( "  using CCTK_REALVEC = simd<CCTK_REAL>;",file=fd)
                             print( "  constexpr std::size_t CCTK_VECSIZE CCTK_ATTRIBUTE_UNUSED = std::tuple_size_v<CCTK_REALVEC>;",file=fd)
-                            print( "  constexpr auto DI CCTK_ATTRIBUTE_UNUSED = PointDesc::DI;",file=fd)
                             print( "  const Loop::GF3D5layout CCTK_ATTRIBUTE_UNUSED VVV_layout(cctkGH, {0,0,0});",file=fd)
                             print( "  const Loop::GF3D5layout CCTK_ATTRIBUTE_UNUSED VVC_layout(cctkGH, {0,0,1});",file=fd)
                             print( "  const Loop::GF3D5layout CCTK_ATTRIBUTE_UNUSED VCV_layout(cctkGH, {0,1,0});",file=fd)

--- a/finite_difference_helpers.py
+++ b/finite_difference_helpers.py
@@ -262,13 +262,13 @@ def ijk_carpetx(idx4):
         if ff == 0:
             pass
         elif ff == 1:
-            result += f("+PointDesc::DI[{i}]")
+            result += f("+p.DI[{i}]")
         elif ff == -1:
-            result += f("-PointDesc::DI[{i}]")
+            result += f("-p.DI[{i}]")
         elif ff < 0:
-            result += f("-{-ff}*PointDesc::DI[{i}]")
+            result += f("-{-ff}*p.DI[{i}]")
         else:
-            result += f("+{ff}*PointDesc::DI[{i}]")
+            result += f("+{ff}*p.DI[{i}]")
     return result
 
 def ijkl_string(idx4, FDparams):


### PR DESCRIPTION
CarpetX recently changed the way the DI member of the PointDesc structure is accessed. This change re-enables compilation with the latest CarpetX.