### PR TITLE
Fixed BSSN Unit Test for NRPyLaTeX v1.3

### DIFF
--- a/.github/broken-github-actions-core_Jupyter_notebooks_latestsympy-MacOS12.yml
+++ b/.github/broken-github-actions-core_Jupyter_notebooks_latestsympy-MacOS12.yml
@@ -29,7 +29,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         python -m pip install --upgrade nbconvert
-        python -m pip install testfixtures sympy mpmath jupyter matplotlib scipy nrpylatex
+        python -m pip install testfixtures sympy mpmath jupyter matplotlib scipy
+        python -m pip install git+https://github.com/zachetienne/nrpylatex.git
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: UnitTests
       run: |

--- a/.github/workflows/github-actions-MacOS12.yml
+++ b/.github/workflows/github-actions-MacOS12.yml
@@ -25,7 +25,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         python -m pip install --upgrade nbconvert
-        python -m pip install testfixtures sympy mpmath jupyter matplotlib scipy nrpylatex clang_format
+        python -m pip install testfixtures sympy mpmath jupyter matplotlib scipy clang_format
+        python -m pip install git+https://github.com/zachetienne/nrpylatex.git
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: UnitTests
       run: |

--- a/.github/workflows/github-actions-ubuntu20.yml
+++ b/.github/workflows/github-actions-ubuntu20.yml
@@ -36,7 +36,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         python -m pip install --upgrade nbconvert
-        python -m pip install testfixtures ${{ matrix.sympy-version }} mpmath jupyter matplotlib scipy nrpylatex clang_format
+        python -m pip install testfixtures ${{ matrix.sympy-version }} mpmath jupyter matplotlib scipy clang_format
+        python -m pip install git+https://github.com/zachetienne/nrpylatex.git
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Core Jupyter notebook testsuite
       run: |
@@ -71,7 +72,8 @@ jobs:
         python -m pip install --upgrade pip setuptools
         python -m pip install --upgrade nbconvert
         python -m pip install --upgrade git+https://github.com/sympy/sympy/
-        python -m pip install testfixtures mpmath jupyter matplotlib scipy nrpylatex clang_format
+        python -m pip install testfixtures mpmath jupyter matplotlib scipy clang_format
+        python -m pip install git+https://github.com/zachetienne/nrpylatex.git
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Core Jupyter notebook testsuite
       run: |
@@ -107,7 +109,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         python -m pip install --upgrade nbconvert
-        python -m pip install testfixtures ${{ matrix.sympy-version }} mpmath jupyter matplotlib scipy nrpylatex clang_format
+        python -m pip install testfixtures ${{ matrix.sympy-version }} mpmath jupyter matplotlib scipy clang_format
+        python -m pip install git+https://github.com/zachetienne/nrpylatex.git
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: UnitTests
       run: |

--- a/.github/workflows/github-actions-ubuntu22.yml
+++ b/.github/workflows/github-actions-ubuntu22.yml
@@ -37,7 +37,8 @@ jobs:
         python -m pip install --upgrade pip setuptools
         python -m pip install --upgrade nbconvert
         python -m pip install --upgrade git+https://github.com/sympy/sympy/
-        python -m pip install testfixtures mpmath jupyter matplotlib scipy nrpylatex clang_format
+        python -m pip install testfixtures mpmath jupyter matplotlib scipy clang_format
+        python -m pip install git+https://github.com/zachetienne/nrpylatex.git
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Core Jupyter notebook testsuite
       run: |
@@ -71,7 +72,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         python -m pip install --upgrade nbconvert
-        python -m pip install testfixtures sympy mpmath jupyter matplotlib scipy nrpylatex clang_format
+        python -m pip install testfixtures sympy mpmath jupyter matplotlib scipy clang_format
+        python -m pip install git+https://github.com/zachetienne/nrpylatex.git
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Core Jupyter notebook testsuite
       run: |
@@ -106,7 +108,8 @@ jobs:
         python -m pip install --upgrade pip setuptools
         python -m pip install --upgrade nbconvert
         python -m pip install --upgrade git+https://github.com/sympy/sympy/
-        python -m pip install testfixtures mpmath jupyter matplotlib scipy nrpylatex clang_format
+        python -m pip install testfixtures mpmath jupyter matplotlib scipy clang_format
+        python -m pip install git+https://github.com/zachetienne/nrpylatex.git
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: UnitTests
       run: |

--- a/.github/workflows/github-actions-windows2022.yml
+++ b/.github/workflows/github-actions-windows2022.yml
@@ -29,7 +29,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip setuptools
         python -m pip install --upgrade nbconvert
-        python -m pip install testfixtures sympy mpmath jupyter matplotlib scipy nrpylatex clang_format
+        python -m pip install testfixtures sympy mpmath jupyter matplotlib scipy clang_format
+        python -m pip install git+https://github.com/zachetienne/nrpylatex.git
     - name: Core Jupyter notebook testsuite
       run: |
         bash ./UnitTesting/run_NRPy_UnitTests.sh python3

--- a/UnitTesting/run_NRPy_UnitTests.sh
+++ b/UnitTesting/run_NRPy_UnitTests.sh
@@ -75,16 +75,15 @@ then
     fi
     echo Doctest of cse_helpers.py finished.
 fi
-# Uncomment this test when parse_BSSN is fixed.
-# for file in tests/test_parse_BSSN.py; do
-#     echo Running unittest on file: $file
-#     $PYTHONEXEC $file
-#     if [ $? == 1 ]
-#     then
-#         failed_unittest=1
-#     fi
-#     echo Unittest of $file finished.
-# done
+for file in tests/test_parse_BSSN.py; do
+    echo Running unittest on file: $file
+    $PYTHONEXEC $file
+    if [ $? == 1 ]
+    then
+        failed_unittest=1
+    fi
+    echo Unittest of $file finished.
+done
 
 # Checking failed_tests.txt to see what failed
 contents=$(<$failed_tests_file)

--- a/sugar.py
+++ b/sugar.py
@@ -97,7 +97,7 @@ def _latex_def(basename, fmt, gf, args):
             _latex_def(basename, fmt, gf[i], args + [coords[i]])
     else:
         indexes = fmt % tuple(args)
-        latex = f("% \\text{{{basename}}}{indexes} = \\text{{{gf}}}")
+        latex = f("% \\mathrm{{{basename}}}{indexes} = \\mathrm{{{gf}}}")
         parse_latex(latex)
 
 
@@ -114,7 +114,7 @@ def match_expr(expr):
         g = re.match(r'''(?x)
         \s+| # spaces
         %.*| # comments
-        \\text{([A-Za-z_]+)}| # var name, group 1
+        \\mathrm{([A-Za-z_]+)}| # var name, group 1
         \\(hat|tilde|bar){\\?([A-Za-z_]+)}| # var name, group 2 and 3
         \\?([A-Za-z]+)| # var name, group 4
         ([\^_]){\ *((?:[a-z]\ )*[a-z])\ *}| # multi-index, group 5 and 6
@@ -670,7 +670,7 @@ def geneqns3(eqn, DIM=3, globs=None, loop=False):
 def geneqns2(lhs, rhs, DIM=3, globs=None, loop=False):
     if globs is None:
         globs = currentframe().f_back.f_globals
-    lhs_str = r"\text{result}"
+    lhs_str = r"\mathrm{result}"
     last = ""
     suffix = ""
 

--- a/tests/test_parse_BSSN.py
+++ b/tests/test_parse_BSSN.py
@@ -24,75 +24,75 @@ class TestParser(unittest.TestCase):
             % ignore "\begin{align}" "\end{align}" "\\%" "\qquad"
 
             \begin{align}
-                % define deltaDD --dim 3 --kron
-                % \hat{\gamma}_{ij} = \delta_{ij}
+                % define gammahatDD --dim 3 --zeros
+                % \hat{\gamma}_{ii} = 1 % noimpsum
                 % assign gammahatDD --metric
-                % define hDD --dim 3 --deriv dD --sym sym01
+                % define hDD --dim 3 --suffix dD --sym sym01
                 % \bar{\gamma}_{ij} = h_{ij} + \hat{\gamma}_{ij}
-                % assign gammabarDD --deriv dD --metric
+                % assign gammabarDD --suffix dD --metric
 
-                % srepl "\beta" -> "\text{vet}"
-                % define vetU --dim 3 --deriv dD
+                % srepl "\beta" -> "\mathrm{vet}"
+                % define vetU --dim 3 --suffix dD
                 %% upwind pattern inside Lie derivative expansion
-                % srepl "\text{vet}^{<1..>} \partial_{<1..>}" -> "\text{vet}^{<1..>} % deriv dupD
+                % srepl "\mathrm{vet}^{<1..>} \partial_{<1..>}" -> "\mathrm{vet}^{<1..>} % suffix dupD
                 \partial_{<1..>}" --persist
                 %% substitute tensor identity (see appropriate BSSN notebook)
-                % srepl "\bar{D}_k \text{vet}^k" -> "(\partial_k \text{vet}^k + \frac{\partial_k \text{gammahatdet} \text{vet}^k}{2 \text{gammahatdet}})"
+                % srepl "\bar{D}_k \mathrm{vet}^k" -> "(\partial_k \mathrm{vet}^k + \frac{\partial_k \mathrm{gammahatdet} \mathrm{vet}^k}{2 \mathrm{gammahatdet}})"
 
-                % srepl "\bar{A}" -> "\text{a}"
-                % define aDD --dim 3 --deriv dD --sym sym01
+                % srepl "\bar{A}" -> "\mathrm{a}"
+                % define aDD --dim 3 --suffix dD --sym sym01
                 % assign aDD --metric gammabar
-                % srepl "\partial_t \bar{\gamma}" -> "\text{h_rhs}"
+                % srepl "\partial_t \bar{\gamma}" -> "\mathrm{h_rhs}"
                 \partial_t \bar{\gamma}_{ij} &= \mathcal{L}_\beta \bar{\gamma}_{ij} + \frac{2}{3} \bar{\gamma}_{ij} \left(\alpha \bar{A}^k{}_k - \bar{D}_k \beta^k\right) - 2 \alpha \bar{A}_{ij} \\
 
-                % define cf trK --dim 3 --deriv dD
-                % srepl "K" -> "\text{trK}"
+                % define cf trK --dim 3 --suffix dD
+                % srepl "K" -> "\mathrm{trK}"
                 %% replace 'phi' with conformal factor cf = W = e^{-2\phi}
-                % srepl "e^{-4\phi}" -> "\text{cf}^2"
-                % srepl "\partial_t \phi = <1..> \\" -> "\text{cf_rhs} = -2 \text{cf} (<1..>) \\"
-                % srepl "\partial_{<1..>} \phi" -> "\partial_{<1..>} \text{cf} \frac{-1}{2 \text{cf}}" --persist
-                % srepl "\partial_<1> \phi" -> "\partial_<1> \text{cf} \frac{-1}{2 \text{cf}}"
+                % srepl "e^{-4\phi}" -> "\mathrm{cf}^2"
+                % srepl "\partial_t \phi = <1..> \\" -> "\mathrm{cf_rhs} = -2 \mathrm{cf} (<1..>) \\"
+                % srepl "\partial_{<1..>} \phi" -> "\partial_{<1..>} \mathrm{cf} \frac{-1}{2 \mathrm{cf}}" --persist
+                % srepl "\partial_<1> \phi" -> "\partial_<1> \mathrm{cf} \frac{-1}{2 \mathrm{cf}}"
                 \partial_t \phi &= \mathcal{L}_\beta \phi + \frac{1}{6} \left(\bar{D}_k \beta^k - \alpha K \right) \\
 
-                % define alpha --dim 3 --deriv dD
-                % srepl "\partial_t \text{trK}" -> "\text{trK_rhs}"
+                % define alpha --dim 3 --suffix dD
+                % srepl "\partial_t \mathrm{trK}" -> "\mathrm{trK_rhs}"
                 \partial_t K &= \mathcal{L}_\beta K + \frac{1}{3} \alpha K^2 + \alpha \bar{A}_{ij} \bar{A}^{ij}
                     - e^{-4\phi} \left(\bar{D}_i \bar{D}^i \alpha + 2 \bar{D}^i \alpha \bar{D}_i \phi\right) \\
 
-                % srepl "\bar{\Lambda}" -> "\text{lambda}"
-                % define lambdaU --dim 3 --deriv dD
+                % srepl "\bar{\Lambda}" -> "\mathrm{lambda}"
+                % define lambdaU --dim 3 --suffix dD
                 % \Delta^k_{ij} = \bar{\Gamma}^k_{ij} - \hat{\Gamma}^k_{ij}
                 % assign DeltaUDD --metric gammabar
                 % \Delta^k = \bar{\gamma}^{ij} \Delta^k_{ij}
-                % srepl "\partial_t \text{lambda}" -> "\text{Lambdabar_rhs}"
+                % srepl "\partial_t \mathrm{lambda}" -> "\mathrm{Lambdabar_rhs}"
                 \partial_t \bar{\Lambda}^i &= \mathcal{L}_\beta \bar{\Lambda}^i + \bar{\gamma}^{jk} \hat{D}_j \hat{D}_k \beta^i
                     + \frac{2}{3} \Delta^i \bar{D}_k \beta^k + \frac{1}{3} \bar{D}^i \bar{D}_k \beta^k \\%
                     &\qquad- 2 \bar{A}^{ij} \left(\partial_j \alpha - 6 \alpha \partial_j \phi\right)
                     + 2 \alpha \bar{A}^{jk} \Delta^i_{jk} - \frac{4}{3} \alpha \bar{\gamma}^{ij} \partial_j K \\
 
-                % define RbarDD --dim 3 --deriv dD --sym sym01
+                % define RbarDD --dim 3 --suffix dD --sym sym01
                 X_{ij} &= -2 \alpha \bar{D}_i \bar{D}_j \phi + 4 \alpha \bar{D}_i \phi \bar{D}_j \phi
                     + 2 \bar{D}_i \alpha \bar{D}_j \phi + 2 \bar{D}_j \alpha \bar{D}_i \phi
                     - \bar{D}_i \bar{D}_j \alpha + \alpha \bar{R}_{ij} \\
                 \hat{X}_{ij} &= X_{ij} - \frac{1}{3} \bar{\gamma}_{ij} \bar{\gamma}^{kl} X_{kl} \\
-                % srepl "\partial_t \text{a}" -> "\text{a_rhs}"
+                % srepl "\partial_t \mathrm{a}" -> "\mathrm{a_rhs}"
                 \partial_t \bar{A}_{ij} &= \mathcal{L}_\beta \bar{A}_{ij} - \frac{2}{3} \bar{A}_{ij} \bar{D}_k \beta^k
                     - 2 \alpha \bar{A}_{ik} \bar{A}^k_j + \alpha \bar{A}_{ij} K + e^{-4\phi} \hat{X}_{ij} \\
 
-                % srepl "\partial_t \alpha" -> "\text{alpha_rhs}"
+                % srepl "\partial_t \alpha" -> "\mathrm{alpha_rhs}"
                 \partial_t \alpha &= \mathcal{L}_\beta \alpha - 2 \alpha K \\
 
-                % srepl "B" -> "\text{bet}"
-                % define betU --dim 3 --deriv dD
-                % srepl "\partial_t \text{vet}" -> "\text{vet_rhs}"
-                \partial_t \beta^i &= \left[\beta^j % deriv dupD
+                % srepl "B" -> "\mathrm{bet}"
+                % define betU --dim 3 --suffix dD
+                % srepl "\partial_t \mathrm{vet}" -> "\mathrm{vet_rhs}"
+                \partial_t \beta^i &= \left[\beta^j % suffix dupD
                 \bar{D}_j \beta^i\right] + B^i \\
 
                 % define eta --const
-                % srepl "\partial_t \text{bet}" -> "\text{bet_rhs}"
-                \partial_t B^i &= \left[\beta^j % deriv dupD
+                % srepl "\partial_t \mathrm{bet}" -> "\mathrm{bet_rhs}"
+                \partial_t B^i &= \left[\beta^j % suffix dupD
                 \bar{D}_j B^i\right]
-                    + \frac{3}{4} \left(\partial_t \bar{\Lambda}^i - \left[\beta^j % deriv dupD
+                    + \frac{3}{4} \left(\partial_t \bar{\Lambda}^i - \left[\beta^j % suffix dupD
                     \bar{D}_j \bar{\Lambda}^i\right]\right) - \eta B^i \\
 
                 % \bar{R} = \bar{\gamma}^{ij} \bar{R}_{ij}


### PR DESCRIPTION
I updated the `tests.test_parse_BSSN` unit test and uncommented the relevant section of `run_NRPy_UnitTests.sh`, which now passes for NRPyLaTeX v1.3. I also replaced each instance of `\text` in `sugar.py` with `\mathrm` since `\text` is now deprecated as of NRPyLaTeX v1.3. It was difficult to support both commands for multi-character symbols with the current implementation of `srepl` and would require considerable refactoring. If `\text` is desired, one can always create an alias using `srepl "\text" -> "\mathrm"`.